### PR TITLE
Adding a different background color to the active tab

### DIFF
--- a/themes/Community-Material-Theme-Darker.json
+++ b/themes/Community-Material-Theme-Darker.json
@@ -721,6 +721,7 @@
     "editor.findMatchHighlightBorder": "#ffffff30",
     "tab.activeBorder": "#80CBC4",
     "tab.activeModifiedBorder": "#616161",
+    "tab.activeBackground": "#131313",
     "tab.unfocusedActiveBorder": "#545454",
     "tab.activeForeground": "#FFFFFF",
     "tab.inactiveForeground": "#616161",


### PR DESCRIPTION
I suggest to change the active tab background color to a darker one. Is easier to see.
This will look like this:
![imagetoupload](https://user-images.githubusercontent.com/74159611/107295376-3b937180-6a3d-11eb-8bff-56b10954d77c.png)
